### PR TITLE
project name extraction support for Windows/platform_agnostic

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -94,7 +94,8 @@ func (env *Environment) Author() string {
 func (env *Environment) Project() string {
 	env.initProject.Do(func() {
 		project := env.Run("git", "rev-parse", "--show-toplevel")
-		env.project = env.Run("basename", project)
+		// env.project = env.Run("basename", project)
+		env.project = filepath.Base(project)
 	})
 	return env.project
 }


### PR DESCRIPTION
Just a line change for this tool to work in Windows. I suppose this will work in other environments.